### PR TITLE
Remove Lodash in favor of ES6

### DIFF
--- a/Swagger.js
+++ b/Swagger.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 module.exports = function(resource) {
   const fixNestedRoutes = function(resource) {
     const routeParts = resource.route.split('/');
@@ -152,8 +150,7 @@ module.exports = function(resource) {
       properties: {},
     };
     // Iterate through each model schema path.
-    _.each(schema.paths, function(path, name) {
-
+    Object.entries(schema.paths).forEach(([name, path]) => {
       // Set the property for the swagger model.
       const property = getProperty(path, name);
       if (name.substr(0, 2) !== '__' && property) {
@@ -199,7 +196,7 @@ module.exports = function(resource) {
 
         // Allow properties to pass back additional definitions.
         if (property.definitions) {
-          definitions = _.merge(definitions, property.definitions);
+          definitions = Object.assign(definitions, property.definitions);
           delete property.definitions;
         }
 
@@ -223,7 +220,7 @@ module.exports = function(resource) {
   };
 
   // Build Swagger definitions.
-  swagger.definitions = _.merge(swagger.definitions, bodyDefinitions);
+  swagger.definitions = Object.assign(swagger.definitions, bodyDefinitions);
 
   // Build Swagger paths
   const methods = resource.methods;
@@ -248,7 +245,7 @@ module.exports = function(resource) {
             type: 'array',
             items: {
               $ref: `#/definitions/${  resource.modelName}`,
-      },
+            },
           },
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2062,7 +2062,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
-    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "mongodb": "^3.5.2",
     "node-paginate-anything": "^1.0.0"

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,25 @@
+
+const zipObject = (props, values) => props.reduce((prev, prop, i) => Object.assign(prev, { [prop]: values[i] }), {});
+
+const isObjectLike = (obj) => obj !== null && typeof obj === 'object';
+
+const get = (obj, path, defaultValue) => path.split('.').reduce((a, c) => (a && a[c] ? a[c] : (defaultValue || null)), obj);
+
+const set = (obj, path, value) => {
+    if (Object(obj) !== obj) return obj;
+    // If not yet an array, get the keys from the string-path
+    if (!Array.isArray(path)) path = path.toString().match(/[^.[\]]+/g) || [];
+    // Split the path. Note: last index is the value key
+    path.slice(0,-1).reduce((a, c, i) =>
+         Object(a[c]) === a[c] // Does the key exist and is its value an object?
+             // Yes: then follow that path
+             ? a[c]
+             // No: create the key. Is the next key a potential array-index?
+             : a[c] = Math.abs(path[i+1])>>0 === +path[i+1]
+                   ? [] // Yes: assign a new array object
+                   : {}, // No: assign a new plain object
+         obj)[path[path.length-1]] = value; // Finally assign the value to the last key
+    return obj;
+};
+
+module.exports = { zipObject, isObjectLike, get, set };


### PR DESCRIPTION
Since Node 6 and 8 are both EOL, using lodash is no longer a requirement.